### PR TITLE
Stretch HP bar to full width (for wider screens)

### DIFF
--- a/client/src/PokemonStats.css
+++ b/client/src/PokemonStats.css
@@ -18,7 +18,6 @@
 
 .healthBar {
   position: relative;
-  width: 250px;
   height: 20px;
   background: #506757;
   padding: 6px;
@@ -28,8 +27,8 @@
 
 .healthName {
   position: absolute;
-  top: 50%;
-  left: 5%;
+  top: 17px;
+  left: 15px;
   background: -webkit-linear-gradient(#F8E71C 0%, #F5A623 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -40,13 +39,13 @@
 .healthPoints,
 .healthDamage {
   position: absolute;
-  width: 200px;
-  transition: all 1s ease;
+  transition: width 1s ease;
 }
 
 .healthPoints {
   top: 4px;
   right: 4px;
+  width: calc(100% - 65px);
   border-width: 2px;
   border-style: solid;
   border-color: #FFF;

--- a/client/src/components/PokemonStats.jsx
+++ b/client/src/components/PokemonStats.jsx
@@ -10,7 +10,7 @@ const PokemonStats = (props) => {
 
   let healthPoints = {
     'height': '20px',
-    'width': '200px',
+    'width': 'calc(100% - 65px)',
     'background': '#54645E', // grey
     'borderRadius': '20px'
   };
@@ -24,7 +24,7 @@ const PokemonStats = (props) => {
 
   if (damage === 1) {
     healthDamage.borderRadius = '20px';
-  } else if (damage >= 0.95 && damage <= 1) {
+  } else if (damage >= 0.65 && damage <= 1) {
     healthDamage.borderRadius = '20px 0 0 20px';
   } else if (damage >= 0.45 && damage <= 0.65) {
     healthDamage.background = '#F8DE33'; // orange


### PR DESCRIPTION
(fix #78) Allow HP bars to stretch entire width of their bounding boxes on wider screens.